### PR TITLE
Fix compilation warnings about possible loss of data

### DIFF
--- a/include/msgpack/adaptor/ext.hpp
+++ b/include/msgpack/adaptor/ext.hpp
@@ -58,7 +58,7 @@ public:
         return &m_data[1];
     }
     uint32_t size() const {
-        return m_data.size() - 1;
+        return static_cast<uint32_t>(m_data.size()) - 1;
     }
     bool operator== (const ext& x) const {
         return m_data == x.m_data;


### PR DESCRIPTION
On Visual Studio 2015 the compiler warns that when converting from size_t (may be 64 bit) to uint32_t there is possible loss of data.
