### PR TITLE
Support vectors of non-default-constructible values in c++11 mode

### DIFF
--- a/include/msgpack/adaptor/vector.hpp
+++ b/include/msgpack/adaptor/vector.hpp
@@ -32,6 +32,25 @@ MSGPACK_API_VERSION_NAMESPACE(v1) {
 
 namespace adaptor {
 
+#if !defined(MSGPACK_USE_CPP03)
+template <typename T>
+struct as<std::vector<T>> {
+    std::vector<T> operator()(const msgpack::object& o) const {
+        if (o.type != msgpack::type::ARRAY) { throw msgpack::type_error(); }
+        std::vector<T> v;
+        if (o.via.array.size > 0) {
+            msgpack::object* p = o.via.array.ptr;
+            msgpack::object* const pend = o.via.array.ptr + o.via.array.size;
+            do {
+                v.emplace_back(p->as<T>());
+                ++p;
+            } while (p < pend);
+        }
+        return v;
+    }
+};
+#endif
+
 template <typename T>
 struct convert<std::vector<T> > {
     msgpack::object const& operator()(msgpack::object const& o, std::vector<T>& v) const {


### PR DESCRIPTION
Recently was added support for non-default-constructible classes using as<T>.
But there should be the similar functionality for containers of such values.

I've just created initial version for vector<T>, but it is not final patch I am expecting to be merged into msgpack. There must be support for other container types (e.g. map) and proper std::enable_if checks.
I do not feel comfortable to create full patch, but expect that Takatoshi Kondo or other maintainers will create polished patch. This is just suggested idea.
